### PR TITLE
fix permissions in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -11,4 +11,7 @@ jobs:
     uses: ./.github/workflows/code-quality.yaml
   release:
     name: "[CD] Release"
+    permissions:
+      contents: write
+      pull-requests: write
     uses: ./.github/workflows/release.yaml

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,16 +3,14 @@ name: Release
 on:
   workflow_call:
 
-permissions: {}
-
 jobs:
   release:
     # Prevent the action from running on forks
     if: github.repository == 'Henskelis/nh-poc'
+    name: Release
     permissions:
       contents: write
       pull-requests: write
-    name: Release
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
The deploy workflow failed because of a permission issue. This should fix it.