### PR TITLE
run release job after code quality checks

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -10,6 +10,7 @@ jobs:
     name: "[CD] Code Quality"
     uses: ./.github/workflows/code-quality.yaml
   release:
+    needs: code-quality
     name: "[CD] Release"
     permissions:
       contents: write


### PR DESCRIPTION
Require the code quality job to complete before running the release job.