### PR TITLE
fix: release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,12 +27,14 @@ jobs:
           cache: pnpm
       - name: Install dependencies
         run: pnpm install
+      - name: Build packages and docs
+        run: pnpm build
       - name: Version and publish packages
         uses: "changesets/action@v1"
         with:
           title: Version packages
           commit: version packages
-          publish: pnpm build && pnpm changeset publish
+          publish: pnpm release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/packages/animations/package.json
+++ b/packages/animations/package.json
@@ -13,6 +13,7 @@
     "build:dev:src": "./scripts/build.js --watch",
     "build": "pnpm clean && tsc && ./scripts/build.js",
     "clean": "rm -rf dist *.tsbuildinfo",
+    "release": "pnpm build && pnpm changeset publish",
     "ts-check": "tsc --emitDeclarationOnly false --noEmit"
   },
   "main": "./dist/index.js",


### PR DESCRIPTION
The Changeset action fails to execute multiple commands when passed to the publish input.
This PR fixes the issue by moving the commands to a specific script which is passed to the publish input.