### PR TITLE
avoid publishing of a package

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,18 +12,15 @@ jobs:
       pull-requests: write
     name: Release packages
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node: [20]
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v4
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-      - name: Setup node ${{ matrix.node }}
+      - name: Setup node 20
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node }}
+          node-version: 20
           cache: pnpm
       - name: Install dependencies
         run: pnpm install

--- a/packages/hc-forms/package.json
+++ b/packages/hc-forms/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@henskelis/bundled-package",
   "version": "0.0.0",
+  "private": true,
   "description": "Easy integration of HC forms in a web page",
   "author": "Henskelis",
   "keywords": ["form", "integration", "web", "component", "web component"],


### PR DESCRIPTION
This PR sets the bundled package private to prevent Changeset to publish it as its not yet ready.
It would be published even if the version is 0.0.0 (not ideal behaviour but that's the way it works 😕).